### PR TITLE
Use python2 in shebang

### DIFF
--- a/httpscan.py
+++ b/httpscan.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- encoding: utf-8 -*-
 #
 # Multithreaded asynchronous HTTP scanner.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- encoding: utf-8 -*-
 #
 # Main setup script


### PR DESCRIPTION
Some distros use Python 3 as a default Python version. Since this script doesn't work with Python3 as there is no Gevent for said version, always use Python 2 by default.
